### PR TITLE
feat: fix water code using lerp and fixed moving time

### DIFF
--- a/Assets/02.Scripts/WaterController.cs
+++ b/Assets/02.Scripts/WaterController.cs
@@ -8,13 +8,15 @@ public class WaterController : MonoBehaviour
     public float waterLevelMax = 100.0f; // Maximum height of water
     public float waterLevelMin = 0.0f; // Minimum height of water
     public float waterLevelTargetUnit = 1.0f; // Target height of water
-    public float riseSpeed = 0.1f; // Speed at which water rises per second
+    public float timeToReachTarget = 2.0f; // 목표에 도달할 시간
     
     // Internal variables (But made public for debugging)
     public float initialPositionY;
     public bool isHeightChanging = false;
-    public bool isRising = false; // true if height of water is rising, false if height of water is lowering
     public float waterLevelTarget; // Target height of water
+    
+    private float elapsedTime = 0.0f;
+    private float startHeight; // 현재 높이를 저장할 변수
 
     void Start()
     {
@@ -31,18 +33,22 @@ public class WaterController : MonoBehaviour
     {
         if (isHeightChanging)
         {
-            if (isRising && transform.position.y >= waterLevelTarget)
-            {                    
-                isHeightChanging = false;    
-            }
-            else if (!isRising && transform.position.y <= waterLevelTarget)
+            // 경과 시간 갱신
+            elapsedTime += Time.deltaTime;
+            float t = Mathf.Clamp01(elapsedTime / timeToReachTarget); // 진행률 계산
+
+            // 부드러운 가속/감속을 적용하여 높이 변경
+            float smoothStepValue = Mathf.SmoothStep(0, 1, t);
+            float newY = Mathf.LerpUnclamped(startHeight, waterLevelTarget, smoothStepValue);
+
+            transform.position = new Vector3(transform.position.x, newY, transform.position.z);
+
+            // 목표에 도달했으면 높이 변경 중지 및 초기화
+            if (t >= 1.0f)
             {
+                transform.position = new Vector3(transform.position.x, waterLevelTarget, transform.position.z);
                 isHeightChanging = false;
-            }
-            else
-            {
-                float direction = isRising ? 1 : -1;
-                ChangeWaterLevel(direction * riseSpeed * Time.deltaTime);
+                elapsedTime = 0.0f; // 초기화
             }
         }
     }
@@ -72,28 +78,7 @@ public class WaterController : MonoBehaviour
     private void TriggerChangeWaterLevel()
     {
         isHeightChanging = true;
-        if (waterLevelTarget > transform.position.y)
-        {
-            isRising = true;
-        }
-        else
-        {
-            isRising = false;
-        }
-    }
-    
-    private void ChangeWaterLevel(float amount)
-    {
-        transform.position = new Vector3(transform.position.x, transform.position.y + amount, transform.position.z);
-    }
-    
-    void OnTriggerEnter(Collider other)
-    {
-        
-    }
-
-    void OnTriggerExit(Collider other)
-    {
-        
+        startHeight = transform.position.y; // 현재 높이를 시작 높이로 설정
+        elapsedTime = 0.0f; // 새로운 변화가 시작되므로 경과 시간 초기화
     }
 }

--- a/Assets/02.Scripts/WaterController.cs
+++ b/Assets/02.Scripts/WaterController.cs
@@ -24,9 +24,9 @@ public class WaterController : MonoBehaviour
         waterLevelTarget = initialPositionY;
         
         // ERASE ME: below three lines of codes are for test
-        Invoke("TriggerStepIncreaseWaterLevel", 0.0f);; // increase water level
-        Invoke("TriggerStepIncreaseWaterLevel", 4.0f); // trigger increase water level 4 seconds later
-        Invoke("TriggerStepDecreaseWaterLevel", 8.0f); // trigger decrease water level 8 seconds later
+        Invoke("TriggerStepIncreaseWaterLevel", 2.0f);; // increase water level
+        Invoke("TriggerStepIncreaseWaterLevel", 6.0f); // trigger increase water level 4 seconds later
+        Invoke("TriggerStepDecreaseWaterLevel", 10.0f); // trigger decrease water level 8 seconds later
     }
 
     void Update()
@@ -53,26 +53,34 @@ public class WaterController : MonoBehaviour
         }
     }
     
-    public void TriggerStepIncreaseWaterLevel()
+    public bool TriggerStepIncreaseWaterLevel()
     {
-        waterLevelTarget += waterLevelTargetUnit;
-        if (waterLevelTarget > waterLevelMax)
+        if (isHeightChanging) return false; // If already changing, return false
+
+        if (waterLevelTarget+waterLevelTargetUnit > waterLevelMax)
         {
             Debug.Log("Water level is already at the maximum height.");
-            return;
+            waterLevelTarget = waterLevelMax; // Adjust to max if exceeded
+            return false;
         }
+        waterLevelTarget += waterLevelTargetUnit;
         TriggerChangeWaterLevel();
+        return true; // Successfully initiated height change
     }
     
-    public void TriggerStepDecreaseWaterLevel()
+    public bool TriggerStepDecreaseWaterLevel()
     {
-        waterLevelTarget -= waterLevelTargetUnit;
-        if (waterLevelTarget < waterLevelMin)
+        if (isHeightChanging) return false; // If already changing, return false
+
+        if (waterLevelTarget-waterLevelTargetUnit < waterLevelMin)
         {
             Debug.Log("Water level is already at the minimum height.");
-            return;
+            waterLevelTarget = waterLevelMin; // Adjust to min if exceeded
+            return false;
         }
+        waterLevelTarget -= waterLevelTargetUnit;
         TriggerChangeWaterLevel();
+        return true; // Successfully initiated height change
     }
     
     private void TriggerChangeWaterLevel()


### PR DESCRIPTION
# 함수 수행의 제한 설정
- 높이가 변화 중일 때 높이 변화 요청을 날리면 즉시 return false, otherwise return true and make height move
- 예상되는 높이 변화 결과가 max나 min을 넘어갈 시 nothing happen

# 구현 방식 변화 - redundant (11/10 아침 회의 때 적용 여부 건의)
- lerp를 사용하여 조금 더 자연스러운 움직임 구현 (초반부에 빠르고 후반부에 느리게 움직임)
- 특정한 unit 높이 만큼 특정한 시간(초) 안에 닿도록 구현

### 사용 방법
각 water object마다 WaterController.cs를 할당
사진과 같이 각 water object 별로 원하는 항목 작성
- public float waterLevelMax = 100.0f : water가 도달 가능한 가장 높은 y 좌표 (global)
- public float waterLevelMin = 0.0f : water가 도달 가능한 가장 낮은 y 좌표 (global)
- public float waterLevelTargetUnit = 1.0f : decrease, increase 함수가 한번 불릴 때마다 높아질 y좌표 계수
- public float timeToReachTarget = 2.0f : 위 목표 높이 도달까지 걸리는 시간

![스크린샷 2024-11-10 015409](https://github.com/user-attachments/assets/0d54efe7-9029-4417-b176-0d6b6abe4b55)

- 후에 해당 오브젝트의 TriggerStepIncreaseWaterLevel() / TriggerStepDecreaseWaterLevel() 호출 시 timeToReachTarget 동안 waterLevelTargetUnit 만큼 증가 / 감소


## 영상
### 기존
![ti-2](https://github.com/user-attachments/assets/992a8d15-2802-4e3d-98e7-83725e57dc92)


### 수정 후
![ti](https://github.com/user-attachments/assets/0392d2db-c20c-4b44-b837-5234f9330d1c)
